### PR TITLE
The correct format is option httpchk <method> <uri> accrording to HAProxy 1.4 doc

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -15,7 +15,7 @@ frontend ft_postgresql
 	default_backend bk_db
 
 backend bk_db
-	option httpchk GET
+	option httpchk GET /
 
   server postgresql_127.0.0.1_5432 127.0.0.1:5432 maxconn 100 check port 8008
   server postgresql_127.0.0.1_5433 127.0.0.1:5433 maxconn 100 check port 8009


### PR DESCRIPTION
HAProxy makes an OPTION request without it
